### PR TITLE
Update theme.mdx zIndices

### DIFF
--- a/content/docs/styled-system/theme.mdx
+++ b/content/docs/styled-system/theme.mdx
@@ -392,21 +392,19 @@ stacking order of components.
 import { extendTheme } from '@chakra-ui/react'
 
 const zIndices = {
-  zIndices: {
-    hide: -1,
-    auto: 'auto',
-    base: 0,
-    docked: 10,
-    dropdown: 1000,
-    sticky: 1100,
-    banner: 1200,
-    overlay: 1300,
-    modal: 1400,
-    popover: 1500,
-    skipLink: 1600,
-    toast: 1700,
-    tooltip: 1800,
-  },
+  hide: -1,
+  auto: 'auto',
+  base: 0,
+  docked: 10,
+  dropdown: 1000,
+  sticky: 1100,
+  banner: 1200,
+  overlay: 1300,
+  modal: 1400,
+  popover: 1500,
+  skipLink: 1600,
+  toast: 1700,
+  tooltip: 1800,
 }
 const theme = extendTheme({ zIndices, ...})
 ```


### PR DESCRIPTION
## ⛳️ Current behavior (updates)
bc spread operator, zIndices has a duplicated key

## 🚀 New behavior
Remove duplicated key

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
